### PR TITLE
Create functional insurance website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# yea
+# Seguros XYZ
+
+Este proyecto contiene una página web sencilla para una compañía de seguros.
+
+## Requisitos
+
+- Node.js 18 o superior (sin dependencias externas).
+
+## Uso
+
+1. Ejecuta el servidor:
+   ```bash
+   npm start
+   ```
+2. Abre `http://localhost:3000` en tu navegador.
+
+Las cotizaciones enviadas se guardarán en `data/quotes.json`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "yea",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nosotros - Seguros XYZ</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Compañía de Seguros XYZ</h1>
+    <nav>
+      <a href="index.html">Inicio</a>
+      <a href="about.html">Nosotros</a>
+      <a href="quote.html">Cotizar</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h2>Quiénes somos</h2>
+      <p>Somos líderes en soluciones de seguros, ofreciendo confianza y seguridad a nuestros clientes por más de 20 años.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 Seguros XYZ</p>
+  </footer>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compañía de Seguros</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Compañía de Seguros XYZ</h1>
+    <nav>
+      <a href="index.html">Inicio</a>
+      <a href="about.html">Nosotros</a>
+      <a href="quote.html">Cotizar</a>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h2>Protegemos lo que más valoras</h2>
+      <p>Seguros de vida, hogar y auto a tu medida.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 Seguros XYZ</p>
+  </footer>
+</body>
+</html>

--- a/public/quote.html
+++ b/public/quote.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Solicitar Cotización - Seguros XYZ</title>
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Compañía de Seguros XYZ</h1>
+    <nav>
+      <a href="index.html">Inicio</a>
+      <a href="about.html">Nosotros</a>
+      <a href="quote.html">Cotizar</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h2>Solicitar Cotización</h2>
+      <form id="quote-form">
+        <label>Nombre:<br><input type="text" name="name" required></label><br>
+        <label>Email:<br><input type="email" name="email" required></label><br>
+        <label>Teléfono:<br><input type="tel" name="phone" required></label><br>
+        <label>Detalle:<br><textarea name="details" required></textarea></label><br>
+        <button type="submit">Enviar</button>
+      </form>
+      <div id="msg"></div>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 Seguros XYZ</p>
+  </footer>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,21 @@
+const form = document.getElementById('quote-form');
+const msg = document.getElementById('msg');
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(form));
+    const res = await fetch('/api/quote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    const result = await res.json();
+    if (result.success) {
+      msg.textContent = 'Cotización enviada. ¡Gracias!';
+      form.reset();
+    } else {
+      msg.textContent = 'Error al enviar. Inténtalo de nuevo.';
+      msg.style.color = 'red';
+    }
+  });
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+header {
+  background: #003366;
+  color: white;
+  padding: 1em;
+}
+nav a {
+  color: white;
+  margin-right: 1em;
+  text-decoration: none;
+}
+.hero {
+  background: #f0f0f0;
+  padding: 2em;
+  text-align: center;
+}
+footer {
+  background: #003366;
+  color: white;
+  text-align: center;
+  padding: 1em;
+}
+#msg {
+  margin-top: 1em;
+  color: green;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,71 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const quotesFile = path.join(__dirname, 'data', 'quotes.json');
+
+function sendFile(res, filePath, contentType) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, {'Content-Type': 'text/plain'});
+      res.end('Not Found');
+      return;
+    }
+    res.writeHead(200, {'Content-Type': contentType});
+    res.end(data);
+  });
+}
+
+function handleApiQuote(req, res) {
+  let body = '';
+  req.on('data', chunk => (body += chunk));
+  req.on('end', () => {
+    try {
+      const quote = JSON.parse(body);
+      fs.mkdir(path.dirname(quotesFile), { recursive: true }, err => {
+        if (err) {
+          console.error('Failed to create data directory:', err);
+        }
+        fs.readFile(quotesFile, 'utf8', (err, data) => {
+          const quotes = err ? [] : JSON.parse(data);
+          quotes.push({ ...quote, created: new Date().toISOString() });
+          fs.writeFile(quotesFile, JSON.stringify(quotes, null, 2), err => {
+            if (err) {
+              console.error('Failed to write quote:', err);
+              res.writeHead(500, {'Content-Type': 'application/json'});
+              res.end(JSON.stringify({ success: false }));
+            } else {
+              res.writeHead(200, {'Content-Type': 'application/json'});
+              res.end(JSON.stringify({ success: true }));
+            }
+          });
+        });
+      });
+    } catch (e) {
+      res.writeHead(400, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({ success: false }));
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const url = req.url === '/' ? '/index.html' : req.url;
+  if (req.method === 'POST' && url === '/api/quote') {
+    handleApiQuote(req, res);
+    return;
+  }
+  const ext = path.extname(url);
+  const contentType = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+    '.json': 'application/json'
+  }[ext] || 'text/plain';
+  const filePath = path.join(__dirname, 'public', url);
+  sendFile(res, filePath, contentType);
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add simple Node-based web server
- create static insurance website pages in Spanish
- document how to run the site in README

## Testing
- `npm start` *(server started)*
- `curl -s http://localhost:3000/index.html | head -n 5`
- `curl -s -X POST http://localhost:3000/api/quote -H "Content-Type: application/json" -d '{"name":"Ana","email":"ana@example.com","phone":"123","details":"test"}'`

------
https://chatgpt.com/codex/tasks/task_e_687bd99ad7f48320a17cea5f1bbf754c