### PR TITLE
Add full example site with chatbot and dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# yea
+# Proyecto de Ejemplo
+
+Este repositorio contiene una página de ejemplo con un chatbot sencillo, interruptor de tema claro/oscuro, control de tamaño de fuente y secciones de testimonios. Incluye páginas de Política de Privacidad y Términos de Uso.
+
+Abre `index.html` en tu navegador para ver la demostración.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Sitio de ejemplo con chatbot, tema claro/oscuro y testimonios">
+    <meta name="keywords" content="ejemplo, chatbot, testimonios, politica de privacidad, terminos de uso">
+    <title>Proyecto de Ejemplo</title>
+    <link rel="stylesheet" href="style.css">
+    <script defer src="script.js"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'GA_MEASUREMENT_ID');
+    </script>
+</head>
+<body>
+<header>
+    <h1>Bienvenido</h1>
+    <button id="theme-toggle" aria-label="Cambiar tema">🌙</button>
+    <label for="font-size">Tamaño de fuente</label>
+    <input type="range" id="font-size" name="font-size" min="14" max="24" value="16">
+</header>
+<main>
+    <section id="testimonios">
+        <h2>Testimonios</h2>
+        <article>
+            <img src="https://via.placeholder.com/150" alt="Foto de usuario satisfecho">
+            <p>"Excelente servicio y atención." – Cliente A</p>
+        </article>
+    </section>
+    <section id="formulario">
+        <h2>Contáctanos</h2>
+        <form id="contact-form">
+            <label for="nombre">Nombre</label>
+            <input type="text" id="nombre" name="nombre" required>
+
+            <label for="correo">Correo electrónico</label>
+            <input type="email" id="correo" name="correo" required>
+
+            <label for="celular">Celular</label>
+            <input type="tel" id="celular" name="celular" pattern="\+?[0-9]{7,15}" required>
+
+            <button type="submit">Enviar</button>
+        </form>
+    </section>
+</main>
+<a id="whatsapp" href="https://wa.me/123456789" target="_blank" aria-label="Contactar por WhatsApp">WhatsApp</a>
+<button id="chatbot-toggle" aria-label="Abrir chatbot">Chatbot</button>
+<div id="chatbot" hidden>
+    <div id="chat-log"></div>
+    <input type="text" id="chat-input" placeholder="Escribe tu pregunta...">
+    <button id="send-chat">Enviar</button>
+</div>
+<footer>
+    <a href="privacy.html">Política de Privacidad</a> |
+    <a href="terms.html">Términos de Uso</a>
+</footer>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Política de Privacidad</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Política de Privacidad</h1>
+<p>Esta es la política de privacidad de ejemplo.</p>
+<footer>
+    <a href="index.html">Inicio</a>
+</footer>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,58 @@
+const themeToggle = document.getElementById('theme-toggle');
+const fontSizeRange = document.getElementById('font-size');
+const chatbotToggle = document.getElementById('chatbot-toggle');
+const chatbot = document.getElementById('chatbot');
+const chatLog = document.getElementById('chat-log');
+const chatInput = document.getElementById('chat-input');
+const sendChat = document.getElementById('send-chat');
+
+const QA = {
+    'hola': 'Hola! ¿Cómo puedo ayudarte?',
+    'precio': 'Los precios varían según el servicio.',
+    'gracias': '¡De nada!'
+};
+
+function appendMessage(author, text) {
+    const p = document.createElement('p');
+    p.textContent = `${author}: ${text}`;
+    chatLog.appendChild(p);
+    chatLog.scrollTop = chatLog.scrollHeight;
+}
+
+function saveHistory() {
+    localStorage.setItem('chatHistory', chatLog.innerHTML);
+}
+
+function loadHistory() {
+    const data = localStorage.getItem('chatHistory');
+    if (data) {
+        chatLog.innerHTML = data;
+    }
+}
+
+themeToggle.addEventListener('click', () => {
+    document.body.dataset.theme = document.body.dataset.theme === 'dark' ? '' : 'dark';
+});
+
+fontSizeRange.addEventListener('input', () => {
+    document.documentElement.style.setProperty('--font-size', fontSizeRange.value + 'px');
+});
+
+chatbotToggle.addEventListener('click', () => {
+    chatbot.hidden = !chatbot.hidden;
+});
+
+sendChat.addEventListener('click', () => {
+    const msg = chatInput.value.trim().toLowerCase();
+    if (!msg) return;
+    appendMessage('Tú', msg);
+    chatInput.value = '';
+    appendMessage('Bot', 'Escribiendo...');
+    setTimeout(() => {
+        const response = QA[msg] || 'Lo siento, no entiendo tu pregunta.';
+        chatLog.lastChild.textContent = `Bot: ${response}`;
+        saveHistory();
+    }, 500);
+});
+
+loadHistory();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,48 @@
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+    --font-size: 16px;
+}
+[data-theme="dark"] {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+}
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-size: var(--font-size);
+    font-family: sans-serif;
+    margin: 0;
+    padding: 0 1rem;
+}
+#whatsapp {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    background: #25d366;
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 50%;
+    text-decoration: none;
+}
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+#chatbot {
+    position: fixed;
+    bottom: 4rem;
+    right: 1rem;
+    background: var(--bg-color);
+    border: 1px solid #ccc;
+    padding: 1rem;
+    width: 250px;
+    max-height: 300px;
+    overflow-y: auto;
+    animation: fade-in 0.5s ease-in-out;
+}
+#chatbot-toggle {
+    position: fixed;
+    bottom: 5rem;
+    right: 1rem;
+}

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Términos de Uso</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Términos de Uso</h1>
+<p>Estos son los términos de uso de ejemplo.</p>
+<footer>
+    <a href="index.html">Inicio</a>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up sample index.html with meta tags, accessible labels and alt text
- add privacy and terms pages
- implement light/dark theme and font size control
- add simple chatbot with localStorage history
- style page with fade-in animation and external CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880598ac45883209c3ffd71e4233dc9