### PR TITLE
Enable chat send on Enter key

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,4 +55,11 @@ sendChat.addEventListener('click', () => {
     }, 500);
 });
 
+chatInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+        event.preventDefault();
+        sendChat.click();
+    }
+});
+
 loadHistory();


### PR DESCRIPTION
## Summary
- handle Enter key in chat input to trigger message send
- prevent default form submission when sending via keyboard

## Testing
- `node --check script.js && echo 'Syntax OK'`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf497d548320afbf59950d41bcb3